### PR TITLE
Use single quotes, not double quotes, in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "build:remix": "remix build",
     "build:sass": "sass -Inode_modules/@uswds -Inode_modules/@uswds/uswds/packages app/theme.scss app/theme.css",
     "build": "run-s build:sass build:remix",
-    "dev:remix": "remix dev --manual -c \"arc sandbox -e testing --host localhost\"",
+    "dev:remix": "remix dev --manual -c 'arc sandbox -e testing --host localhost'",
     "dev:sass": "sass --watch -Inode_modules/@uswds -Inode_modules/@uswds/uswds/packages app/theme.scss app/theme.css",
-    "dev": "run-p \"dev:*\"",
+    "dev": "run-p 'dev:*'",
     "prepare": "husky install",
-    "clean": "rimraf --glob build app/theme.css* sam.*",
+    "clean": "rimraf --glob build 'app/theme.css*' 'sam.*'",
     "deploy": "arc deploy --no-hydrate --prune --production"
   },
   "dependencies": {


### PR DESCRIPTION
Single quotes prevent shell expansion of globs. Double quotes don't.