### PR TITLE
Lock down arc sandbox to localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build:remix": "remix build",
     "build:sass": "sass -Inode_modules/@uswds -Inode_modules/@uswds/uswds/packages app/theme.scss app/theme.css",
     "build": "run-s build:sass build:remix",
-    "dev:remix": "remix dev --manual -c \"arc sandbox -e testing\"",
+    "dev:remix": "remix dev --manual -c \"arc sandbox -e testing --host localhost\"",
     "dev:sass": "sass --watch -Inode_modules/@uswds -Inode_modules/@uswds/uswds/packages app/theme.scss app/theme.css",
     "dev": "run-p \"dev:*\"",
     "prepare": "husky install",


### PR DESCRIPTION
By default, it listens on all network interfaces. The horror!